### PR TITLE
Proxy API requests to 3001 when running standalone

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "frinx-workflow-ui",
   "version": "1.1.0",
   "private": true,
+  "proxy": "http://localhost:3001",
   "dependencies": {
     "ace-builds": "^1.4.9",
     "axios": "^0.19.2",


### PR DESCRIPTION
Useful in situations when you want to only run frinx-workflow-ui and proxy server without whole frinx-uniconfig-ui.

Signed-off-by: Adam Chmara <adam.chmara1@gmail.com>