### PR TITLE
[FIX] Root URL, redirecting

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -52,7 +52,7 @@ function App(props : { setBuilderActive?: (param: boolean) => void }) {
           />
           <Route
             exact
-            path={[props.frontendUrlPrefix + "/:type", props.frontendUrlPrefix + "/:type/:wfid", "/"]}
+            path={[props.frontendUrlPrefix + "/:type", props.frontendUrlPrefix + "/:type/:wfid"]}
             render={(pp) => (
               <WorkflowList
                 frontendUrlPrefix={props.frontendUrlPrefix}
@@ -62,7 +62,7 @@ function App(props : { setBuilderActive?: (param: boolean) => void }) {
               />
             )}
           />
-          <Redirect from={props.frontendUrlPrefix} to={props.frontendUrlPrefix + "/defs"} />
+          <Redirect to={props.frontendUrlPrefix + "/defs"}/>
         </Switch>
       </BrowserRouter>
     </Provider>

--- a/src/common/Grapher.js
+++ b/src/common/Grapher.js
@@ -217,6 +217,8 @@ class Grapher extends Component<Props, StateType> {
       } else if (vertices[v].tooltip != null) {
         let data = vertices[v].data;
 
+        if (data.taskType === 'final' || data.taskType === 'start') return;
+
         p.setState({
           selectedTask: data.task,
           showSideBar: true,

--- a/src/pages/diagramBuilder/ControlsHeader/BuilderHeader.js
+++ b/src/pages/diagramBuilder/ControlsHeader/BuilderHeader.js
@@ -294,7 +294,7 @@ const BuilderHeader = props => {
   return (
     <Navbar id="builder-header" className="builder-header">
       <Navbar.Brand>
-        <NavLink to="/">
+        <NavLink to="/workflows/defs">
           <XLetter />
           <Logo />
         </NavLink>


### PR DESCRIPTION
Set `/workflows/defs` to be the default (root) URL for workflow-ui as it should be, since the entry point for app is the "Defs" tab. 

The child app (wf-ui) doesn't know about parent root (`/`), therefore it changed the URL to its own root `/` and displayed defs tab - which is incorrect in context where the app is integrated somewhere.

Fix for bug: https://frinxhelpdesk.atlassian.net/browse/FM-459