### PR TITLE
Use stringified JSON as workflow description to store structured data

### DIFF
--- a/src/pages/diagramBuilder/DiagramBuilder.js
+++ b/src/pages/diagramBuilder/DiagramBuilder.js
@@ -240,7 +240,6 @@ class DiagramBuilder extends Component {
 
   // GENERAL INFO MODAL
   showGeneralInfoModal() {
-    this.parseDiagramToJSON();
     this.setState({
       showGeneralInfoModal: !this.state.showGeneralInfoModal,
     });

--- a/src/pages/diagramBuilder/GeneralInfoModal/GeneralInfoModal.js
+++ b/src/pages/diagramBuilder/GeneralInfoModal/GeneralInfoModal.js
@@ -4,7 +4,6 @@ import { Modal, Button, Tab, Tabs, ButtonGroup } from "react-bootstrap";
 import DefaultsDescsTab from "./DefaultsDescsTab";
 import OutputParamsTab from "./OutputParamsTab";
 import GeneralParamsTab from "./GeneralParamsTab";
-import { getLabelsFromString } from "../builder-utils";
 
 const GeneralInfoModal = props => {
   const [isWfNameValid, setWfNameValid] = useState(false);
@@ -35,11 +34,28 @@ const GeneralInfoModal = props => {
     props.closeModal();
   };
 
+  const parseJSON = json => {
+    try {
+      return JSON.parse(json);
+    } catch (e) {
+      return null;
+    }
+  }
+
   const handleInput = (value, key) => {
     let finalWf = { ...finalWorkflow };
 
     if (key === "name") {
       validateWorkflowName(value);
+    }
+
+    if (key === "description") {
+      let innerKey = Array.isArray(value) ? "labels" : "description"
+      value = {
+        ...parseJSON(finalWf.description),
+        [innerKey]: value
+      }
+      value = JSON.stringify(value)
     }
 
     finalWf = {
@@ -62,12 +78,21 @@ const GeneralInfoModal = props => {
     setWfNameValid(isValid);
   };
 
+  const jsonParse = (json) => {
+    try {
+      return JSON.parse(json);
+    } catch (e) {
+      return null;
+    }
+  };
+
   const getExistingLabels = () => {
     let workflows = props.workflows || [];
     let labels = [];
-    workflows.forEach(wf => {
-      if (wf.description) {
-        labels.push(...getLabelsFromString(wf.description));
+    workflows.forEach((wf) => {
+      let wfLabels = jsonParse(wf.description)?.labels;
+      if (wfLabels) {
+        labels.push(...wfLabels);
       }
     });
     return new Set(labels);

--- a/src/pages/diagramBuilder/GeneralInfoModal/GeneralParamsTab.js
+++ b/src/pages/diagramBuilder/GeneralInfoModal/GeneralParamsTab.js
@@ -10,7 +10,6 @@ import {
 } from "react-bootstrap";
 import { Typeahead } from "react-bootstrap-typeahead";
 import { workflowDescriptions } from "../../../constants";
-import { getLabelsFromString } from "../builder-utils";
 
 const GeneralParamsTab = props => {
   const { isWfNameLocked, isWfNameValid } = props;
@@ -74,14 +73,23 @@ const GeneralParamsTab = props => {
     </Form.Group>
   );
 
+  const parseJson = (json) => {
+    try {
+      return JSON.parse(json);
+    } catch (e) {
+      return null;
+    }
+  };
+
   const description = () => {
-    let desc = "";
+    let desc = props.finalWf.description || "";
     let labels = [];
     let existingLabels = [];
+    let description = parseJson(props.finalWf.description)
 
-    if (props.finalWf["description"]) {
-      desc = props.finalWf["description"].split(" - ")[0];
-      labels = getLabelsFromString(props.finalWf["description"]);
+    if (description) {
+      desc = description.description;
+      labels = description.labels;
       existingLabels = Array.from(props.getExistingLabels());
     }
 
@@ -93,25 +101,21 @@ const GeneralParamsTab = props => {
           </InputGroup.Prepend>
           <Form.Control
             type="input"
-            onChange={e =>
-              props.handleInput(e.target.value + " - " + labels, "description")
-            }
+            onChange={(e) => props.handleInput(e.target.value, "description")}
             value={desc}
           />
         </InputGroup>
         <Typeahead
-          id='new-label-typehead'
+          id="new-label-typehead"
           allowNew
           multiple
           clearButton
           newSelectionPrefix="Add a new label: "
           defaultSelected={labels}
           value={labels}
-          onChange={e =>
+          onChange={(e) =>
             props.handleInput(
-              desc +
-                " - " +
-                e.map(item => (item.label ? item.label.toUpperCase() : item)),
+              e.map((item) => (item.label ? item.label.toUpperCase() : item)),
               "description"
             )
           }

--- a/src/pages/diagramBuilder/Sidemenu/SideMenuItem.js
+++ b/src/pages/diagramBuilder/Sidemenu/SideMenuItem.js
@@ -6,7 +6,11 @@ const SideMenuItem = props => {
   let description = null;
 
   if (props.model.description) {
-    description = props.model.description.split('-')[0];
+    try {
+      description = JSON.parse(props.model.description)?.description
+    } catch (e) {
+      description = props.model.description
+    }
   }
 
   return (

--- a/src/pages/diagramBuilder/Sidemenu/Sidemenu.js
+++ b/src/pages/diagramBuilder/Sidemenu/Sidemenu.js
@@ -16,6 +16,14 @@ import SideMenuItem from './SideMenuItem';
 import {getTaskInputsRegex, getWfInputsRegex, hash} from '../builder-utils';
 import { version } from "../../../../package.json";
 
+const jsonParse = json => {
+  try {
+    return JSON.parse(json);
+  } catch (e) {
+    return null;
+  }
+}
+
 const icons = taskDef => {
   const task = taskDef.name;
   switch (task) {
@@ -532,13 +540,7 @@ const Sidemenu = props => {
                 [open === 'Tasks' ? props.tasks : props.workflows]
                   .flat()
                   .map(wf => {
-                    return wf.description
-                      ? wf.description
-                          .split('-')
-                          .pop()
-                          .replace(/\s/g, '')
-                          .split(',')
-                      : null;
+                    return jsonParse(wf.description)?.labels || null
                   })
                   .flat()
                   .filter(item => item !== null),

--- a/src/pages/diagramBuilder/builder-utils.js
+++ b/src/pages/diagramBuilder/builder-utils.js
@@ -48,14 +48,6 @@ export const encode = s => {
   return new Uint8Array(out);
 };
 
-export const getLabelsFromString = str => {
-  let labelsString = str
-    .split("-")
-    .pop()
-    .replace(/ /g, "");
-  return labelsString === "" ? [] : labelsString.split(",");
-};
-
 export const getWfInputs = wf => {
   let taskArray = wf.tasks;
   let inputParams = [];

--- a/src/pages/workflowList/WorkflowDefs/InputModal/InputModal.js
+++ b/src/pages/workflowList/WorkflowDefs/InputModal/InputModal.js
@@ -15,6 +15,14 @@ import { getMountedDevices } from "../../../../store/actions/mountedDevices";
 import { storeWorkflowId } from "../../../../store/actions/builder";
 import { HttpClient as http } from "../../../../common/HttpClient";
 
+const jsonParse = (json) => {
+  try {
+    return JSON.parse(json);
+  } catch (e) {
+    return null;
+  }
+}
+
 const getInputs = (def) => {
   let inputCaptureRegex = /workflow\.input\.([a-zA-Z0-9-_]+)\}/gim
   let match = inputCaptureRegex.exec(def)
@@ -73,7 +81,10 @@ function InputModal(props) {
   const [waitingWfs, setWaitingWfs] = useState([]);
   const name = props.wf.name;
   const version = Number(props.wf.version);
-  const wfdesc = props.wf.description?.split("-")[0] || "";
+  const wfdesc =
+    jsonParse(props.wf.description)?.description ||
+    (jsonParse(props.wf.description)?.description !== "" &&
+    props.wf.description);
   
   const backendApiUrlPrefix = props.backendApiUrlPrefix;
   const frontendUrlPrefix = props.frontendUrlPrefix;

--- a/src/store/actions/builder.js
+++ b/src/store/actions/builder.js
@@ -124,12 +124,14 @@ export const requestUpdateByQuery = (queryIn, labelsIn) => {
     // label filter
     if (labelsIn && labelsIn.length > 0) {
       data.forEach(wf => {
+        var wfLabels;
+
         if (wf.description) {
-          let wfLabels = wf.description
-            .split("-")
-            .pop()
-            .replace(/\s/g, "")
-            .split(",");
+          try {
+            wfLabels = JSON.parse(wf.description)?.labels;
+          } catch (e) {
+            wfLabels = [];
+          }
 
           if (_.intersection(wfLabels, labelsIn).length === labelsIn.length) {
             withLabels.push(wf);


### PR DESCRIPTION
Workflow description now has stringified JSON structure instead of using random delimiters in string.

**Example:** 

`  
"description": "{\"description\":\"Example description\",\"labels\":[\"SIMPLE\",\"UNICONFIG\",\"FAVOURITE\"]}"
`

The default method of just description without labels is also supported: 

`
"description": "Example description"
`

Related: https://github.com/FRINXio/fm-workflows/pull/39
 