### PR TITLE
Improved inputParameters format including more types

### DIFF
--- a/src/pages/diagramBuilder/DiagramBuilder.js
+++ b/src/pages/diagramBuilder/DiagramBuilder.js
@@ -240,6 +240,9 @@ class DiagramBuilder extends Component {
 
   // GENERAL INFO MODAL
   showGeneralInfoModal() {
+    if (!this.state.showGeneralInfoModal) {
+      this.parseDiagramToJSON();
+    } 
     this.setState({
       showGeneralInfoModal: !this.state.showGeneralInfoModal,
     });

--- a/src/pages/diagramBuilder/GeneralInfoModal/DefaultsDescsTab.js
+++ b/src/pages/diagramBuilder/GeneralInfoModal/DefaultsDescsTab.js
@@ -1,42 +1,114 @@
 // @flow
-import React, { useState } from "react";
-import { Button, Col, Form, InputGroup } from "react-bootstrap";
+import React, { useState, useEffect } from "react";
 import { getWfInputsRegex } from "../builder-utils";
+import {
+  Form,
+  Row,
+  Col,
+  InputGroup
+} from "react-bootstrap";
+import Dropdown from 'react-dropdown';
+
 import _ from "lodash";
 
-const createInputParamsList = props => {
-  const existingInputParameters = props.finalWf.inputParameters || [];
+const inputParamsTemplate = {
+  value: "",
+  description: "",
+  type: "string"
+}
+
+const jsonParse = (json) => {
+  try {
+    return JSON.parse(json);
+  } catch (e) {
+    return null;
+  }
+}
+
+const getInputParameters = (props) => {
+  const inputParameters = jsonParse(props.finalWf.inputParameters[0]);
   let inputParametersKeys = Object.keys(getWfInputsRegex(props.finalWf)) || [];
 
-  existingInputParameters.forEach(param => {
-    inputParametersKeys.push(param.match(/^(.*?)\[/)[1]);
-  });
+  let inputParams = inputParametersKeys.map((key) => ({
+    label: key,
+    ...(inputParameters
+      ? inputParameters[key]
+        ? inputParameters[key]
+        : inputParamsTemplate
+      : inputParamsTemplate),
+  }));
 
-  inputParametersKeys = _.uniq(inputParametersKeys);
+  const defaults = ['value', 'description', 'type']
+  inputParams.forEach((param, i) => {
+    defaults.forEach(d => {
+        if(!inputParams[i][d]) {
+          inputParams[i][d] = ""
+        }
+    })
+  })
 
-  return inputParametersKeys;
+  return inputParams;
 };
 
-const DefaultsDescsTab = props => {
-  const inputParamsList = createInputParamsList(props);
-  const [selectedParam, setSelectedParam] = useState(inputParamsList[0]);
+const DefaultsDescsTab = (props) => {
+  const [inputParams, setInputParams] = useState([]);
+  const [selectedParam, setSelectedParam] = useState(getInputParameters(props)[0]?.label);
+  const [selectedParamObj, setSelectedParamObj] = useState({})
 
-  const getDescriptionAndDefault = () => {
-    let inputParameters = props.finalWf.inputParameters || [];
-    let result = [];
+  useEffect(() => {
+    selectParameter(selectedParam);
+  }, [props]);
 
-    inputParameters.forEach(param => {
-      if (param.match(/^(.*?)\[/)[1] === selectedParam) {
-        param.match(/\[(.*?)]/g).forEach(group => {
-          result.push(group.replace(/[[\]']+/g, ""));
-        });
-      }
-    });
-    return result.length > 0 ? result : ["", ""];
+  const selectParameter = (label) => {
+    let inputParams = getInputParameters(props);
+    setInputParams(inputParams)
+    setSelectedParam(label);
+    setSelectedParamObj(_.find(inputParams, { label: label }));
   };
 
-  let currentDescription = getDescriptionAndDefault(selectedParam)[0];
-  let currentDefault = getDescriptionAndDefault(selectedParam)[1];
+  const renderInputFields = (param, i) => {
+    const types = ['string', 'toggle', 'select', 'textarea', 'node_id']
+
+    switch (param[0]) {
+      case "type":
+        return (
+          <Col sm={6} key={`col-${selectedParam}-${i}`}>
+            <Form.Group>
+              <Form.Label>{param[0]}</Form.Label>
+              <Dropdown
+                options={types}
+                onChange={(e) => props.handleInputParams(
+                  selectedParam,
+                  selectedParamObj,
+                  param[0],
+                  e.value
+                )}
+                value={param[1]}
+              />
+            </Form.Group>
+          </Col>          
+        );
+      default:
+        return (
+          <Col sm={6} key={`col-${selectedParam}-${i}`}>
+            <Form.Group>
+              <Form.Label>{param[0]}</Form.Label>
+              <Form.Control
+                defaultValue={param[1]}
+                onChange={(e) =>
+                  props.handleInputParams(
+                    selectedParam,
+                    selectedParamObj,
+                    param[0],
+                    e.target.value
+                  )
+                }
+              />
+            </Form.Group>
+          </Col>
+        );
+    }
+  }
 
   return (
     <div>
@@ -47,58 +119,23 @@ const DefaultsDescsTab = props => {
               <InputGroup.Text>Available input parameters:</InputGroup.Text>
             </InputGroup.Prepend>
             <Form.Control
-              disabled={inputParamsList.length === 0}
-              onClick={e => setSelectedParam(e.target.value)}
+              disabled={inputParams.length === 0}
+              onClick={(e) =>
+                selectParameter(e.target.value)
+              }
               as="select"
             >
-              {inputParamsList.map(param => (
-                <option>{param}</option>
+              {inputParams.map((param) => (
+                <option>{param.label}</option>
               ))}
             </Form.Control>
-            <InputGroup.Append>
-              <Button
-                disabled={inputParamsList.length === 0}
-                title="delete parameter's default and description"
-                onClick={() => props.deleteDefaultAndDesc(selectedParam)}
-                variant="outline-danger"
-              >
-                <i className="fas fa-times" />
-              </Button>
-            </InputGroup.Append>
           </InputGroup>
         </Form.Group>
-        <Form.Row>
-          <Col>
-            <Form.Label>default value</Form.Label>
-            <Form.Control
-              placeholder="default value"
-              disabled={inputParamsList.length === 0}
-              value={currentDefault}
-              onChange={e =>
-                props.handleCustomDefaultAndDesc(
-                  selectedParam,
-                  e.target.value,
-                  currentDescription
-                )
-              }
-            />
-          </Col>
-          <Col>
-            <Form.Label>description</Form.Label>
-            <Form.Control
-              placeholder="description"
-              disabled={inputParamsList.length === 0}
-              value={currentDescription}
-              onChange={e =>
-                props.handleCustomDefaultAndDesc(
-                  selectedParam,
-                  currentDefault,
-                  e.target.value
-                )
-              }
-            />
-          </Col>
-        </Form.Row>
+        <Row>
+          {Object.entries(_.omit(selectedParamObj, "label")).map((param, i) =>
+            renderInputFields(param, i)
+          )}
+        </Row>
       </Form>
     </div>
   );

--- a/src/pages/diagramBuilder/GeneralInfoModal/GeneralInfoModal.js
+++ b/src/pages/diagramBuilder/GeneralInfoModal/GeneralInfoModal.js
@@ -132,6 +132,8 @@ const GeneralInfoModal = props => {
     let finalWf = { ...finalWorkflow };
     let inputParameters = jsonParse(finalWf.inputParameters[0]);
 
+    delete paramObj.label;
+
     let newInputParams = {
       ...inputParameters,
       [paramKey]: {

--- a/src/pages/diagramBuilder/GeneralInfoModal/GeneralInfoModal.js
+++ b/src/pages/diagramBuilder/GeneralInfoModal/GeneralInfoModal.js
@@ -128,41 +128,35 @@ const GeneralInfoModal = props => {
     setFinalWf(finalWf);
   };
 
-  const handleCustomDefaultAndDesc = (param, defaultValue, description) => {
+  const handleInputParams = (paramKey, paramObj, key, value) => {
     let finalWf = { ...finalWorkflow };
-    let inputParameters = finalWf.inputParameters || [];
-    // eslint-disable-next-line no-useless-concat
-    let entry = `${param}` + `[${description}]` + `[${defaultValue}]`;
-    let isUnique = true;
+    let inputParameters = jsonParse(finalWf.inputParameters[0]);
 
-    if (inputParameters.length > 0) {
-      inputParameters.forEach((elem, i) => {
-        if (elem.startsWith(param)) {
-          inputParameters[i] = entry;
-          return (isUnique = false);
-        }
-      });
-    }
-
-    if (isUnique) {
-      inputParameters.push(entry);
-    }
-
-    finalWf = { ...finalWf, inputParameters };
-    setFinalWf(finalWf);
-  };
-
-  const deleteDefaultAndDesc = selectedParam => {
-    let finalWf = { ...finalWorkflow };
-    let inputParameters = finalWf.inputParameters || [];
-
-    inputParameters.forEach((param, i) => {
-      if (param.match(/^(.*?)\[/)[1] === selectedParam) {
-        inputParameters.splice(i, 1);
+    let newInputParams = {
+      ...inputParameters,
+      [paramKey]: {
+        ...paramObj,
+        [key]: key === "options" ?  value.split(',') : value 
       }
-    });
+    };
 
-    finalWf = { ...finalWf, inputParameters };
+    const optionValues = ["toggle", "select"];
+    if (
+      key === "type" &&
+      optionValues.includes(value)
+    ) {
+      newInputParams = {
+        ...newInputParams,
+        [paramKey]: {
+          ...newInputParams[paramKey],
+          options: ['value1','value2']
+        },
+      };
+    } else if (key === "type") {
+      delete newInputParams[paramKey].options
+    }
+
+    finalWf = { ...finalWf, inputParameters: [JSON.stringify(newInputParams)] };
     setFinalWf(finalWf);
   };
 
@@ -184,7 +178,7 @@ const GeneralInfoModal = props => {
     >
       <Modal.Header>
         <Modal.Title>
-          {isNameLocked ? "Edit general informations" : "Create new workflow"}
+          {isNameLocked ? "Edit general information" : "Create new workflow"}
         </Modal.Title>
       </Modal.Header>
       <Modal.Body style={{ padding: "30px" }}>
@@ -211,8 +205,7 @@ const GeneralInfoModal = props => {
           <Tab eventKey={3} title="Defaults & description">
             <DefaultsDescsTab
               finalWf={finalWorkflow}
-              deleteDefaultAndDesc={deleteDefaultAndDesc}
-              handleCustomDefaultAndDesc={handleCustomDefaultAndDesc}
+              handleInputParams={handleInputParams}
             />
           </Tab>
         </Tabs>

--- a/src/pages/diagramBuilder/NodeModal/InputsTab.js
+++ b/src/pages/diagramBuilder/NodeModal/InputsTab.js
@@ -19,22 +19,28 @@ const SELECTFIELD_OPTIONS = {
   expectedType: ['SIMPLE', 'SUB_WORKFLOW']
 };
 
+const jsonParse = (json) => {
+  try {
+    return JSON.parse(json)
+  } catch (e) {
+    return null
+  }
+}
+
 const InputsTab = props => {
   const [customParam, setCustomParam] = useState('');
   const textFieldParams = [];
 
-  const getDescriptionAndDefault = selectedParam => {
-    const inputParameters = props.inputParameters || [];
-    const result = [];
+  const getDescriptionAndDefault = (selectedParam) => {
+    const inputParameters = jsonParse(
+      props.inputParameters ? props.inputParameters[0] : null
+    );
 
-    inputParameters.forEach(param => {
-      if (param.match(/^(.*?)\[/)[1] === selectedParam) {
-        param.match(/\[(.*?)]/g).forEach(group => {
-          result.push(group.replace(/[[\]']+/g, ''));
-        });
-      }
-    });
-    return result.length > 0 ? result : ['', ''];
+    if (!inputParameters) {
+      return null
+    }
+
+    return inputParameters[selectedParam]?.description
   };
 
   const addNewInputParam = e => {
@@ -80,7 +86,7 @@ const InputsTab = props => {
             />
           </InputGroup>
           <Form.Text className="text-muted">
-            {getDescriptionAndDefault(entry[0])[0]}
+            {getDescriptionAndDefault(entry[0])}
           </Form.Text>
         </Form.Group>
       </Col>,
@@ -111,7 +117,7 @@ const InputsTab = props => {
             }}
           />
           <Form.Text className="text-muted">
-            {getDescriptionAndDefault(entry[0])[0]}
+            {getDescriptionAndDefault(entry[0])}
           </Form.Text>
         </Form.Group>
       </Col>,
@@ -132,7 +138,7 @@ const InputsTab = props => {
             value={value}
           />
           <Form.Text className="text-muted">
-            {getDescriptionAndDefault(entry[0])[0]}
+            {getDescriptionAndDefault(entry[0])}
           </Form.Text>
         </Form.Group>
       </Col>
@@ -212,7 +218,7 @@ const InputsTab = props => {
             value={entry[1]}
           />
           <Form.Text className="text-muted">
-            {getDescriptionAndDefault(entry[0])[0]}
+            {getDescriptionAndDefault(entry[0])}
           </Form.Text>
         </Form.Group>
       </Col>


### PR DESCRIPTION
Existing types for now: string, toggle, select, textarea, node_id

Example structure: 

```javascript
  "inputParameters": [
    "{\"template_id\":{\"label\":\"template_id\",\"value\":\"value for template ID\",\"description\":\"description for template ID\",\"type\":\"string\"},\"command\":{\"label\":\"command\",\"value\":\"value1\",\"description\":\"description for command\",\"type\":\"select\",\"options\":[\"value1\",\"value2\",\"value3\"]}}"
  ],
```

![image](https://user-images.githubusercontent.com/32128755/89312870-141bb080-d678-11ea-98c7-11e1ae0e66a5.png)

![image](https://user-images.githubusercontent.com/32128755/89312920-21d13600-d678-11ea-9a59-f7d7299f3640.png)



Signed-off-by: Adam Chmara <adam.chmara1@gmail.com>