### PR TITLE
Split workflow metadata endpoint and scheduling endpoint

### DIFF
--- a/src/pages/workflowList/WorkflowDefs/WorkflowDefs.js
+++ b/src/pages/workflowList/WorkflowDefs/WorkflowDefs.js
@@ -44,8 +44,18 @@ export class WorkflowDefs extends Component {
     this.search();
   }
 
+  metadataUrlSuffix() {
+    // Use standard URL (/metadata/workflow) in case scheduling is disabled
+    // but use a special endpoint that returns workflow metadata with
+    // scheduling info attached (/schedule/metadata/workflow)
+    // if scheduling is supported by the backend
+    return this.context.enableScheduling === false
+      ? '/metadata/workflow'
+      : '/schedule/metadata/workflow';
+  }
+
   componentDidMount() {
-    http.get(this.context.backendApiUrlPrefix + "/metadata/workflow").then((res) => {
+    http.get(this.context.backendApiUrlPrefix + this.metadataUrlSuffix()).then((res) => {
       if (res.result) {
         let size = ~~(res.result.length / this.state.defaultPages);
         let dataset =
@@ -200,7 +210,7 @@ export class WorkflowDefs extends Component {
     workflow.description = JSON.stringify(wfDescription);
 
     http.put(this.context.backendApiUrlPrefix + "/metadata/", [workflow]).then(() => {
-      http.get(this.context.backendApiUrlPrefix + "/metadata/workflow").then((res) => {
+      http.get(this.context.backendApiUrlPrefix + this.metadataUrlSuffix()).then((res) => {
         let dataset =
           res.result.sort((a, b) =>
             a.name > b.name ? 1 : b.name > a.name ? -1 : 0

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,15 @@ module.exports = {
     proxy: {
       '/api/conductor': {
         target: 'http://localhost:3001',
-        secure: false
+        secure: false,
+        // Uncomment below settings when testing frinx-workflow-ui running on host and talking to workflow-proxy in net-auto
+        // target: 'http://localhost:8088',
+        // secure: false,
+        // pathRewrite: {'^/api/conductor' : ''},
+        // headers: {
+        //   'from': 'fb-user',
+        //   'x-tenant-id': 'fb',
+        // }
       }
     }
   },


### PR DESCRIPTION
The tenant proxy in net-auto sent workflwo metadata and scheduling
metadata in the same response to /metadata/workflows

From now on they will be split into 2 different endpoints.
So adjust WorkflowDefs to use proper endpoint based on whether
scheduling is on or off.

Signed-off-by: Maros Marsalek <mmarsalek@frinx.io>