### PR TITLE
Switch graphQL task backend to HTTP

### DIFF
--- a/src/pages/diagramBuilder/Sidemenu/Sidemenu.js
+++ b/src/pages/diagramBuilder/Sidemenu/Sidemenu.js
@@ -174,25 +174,28 @@ else:
       };
     }
     case 'graphQL': {
+      // graphQL task is a simple facade on top of HTTP task
       return {
-        name: 'GLOBAL___GRAPHQL_task',
+        name: props.prefixHttpTask + 'HTTP_task',
         taskReferenceName: 'graphQLTaskRef_' + hash(),
-        type: 'SIMPLE',
         inputParameters: {
-          graphql_request: {
+          http_request: {
             uri: '${workflow.input.uri}',
-            timeout: 1000,
-            graphQLBody:
-                `query queryResourceTypes {
+            method: 'POST',
+            graphQLBody: `query queryResourceTypes {
     QueryResourceTypes{
         ID
         Name
     }
 }`,
+            contentType: 'application/json',
+            headers: {},
+            timeout: 3600,
           },
         },
         optional: false,
         startDelay: 0,
+        type: 'SIMPLE',
       };
     }
     case 'terminate': {

--- a/src/pages/diagramBuilder/WorkflowDiagram.js
+++ b/src/pages/diagramBuilder/WorkflowDiagram.js
@@ -888,7 +888,18 @@ export class WorkflowDiagram {
               break;
             default:
               parentNode = link.targetPort.parent;
-              if (parentNode.name === "RAW") {
+              if (parentNode.name === "graphQL") {
+                // In case of graphQL task, we need to put graphQLBody param into body param
+                // so that we conform to HTTP task API ... and from now on, this will be treated
+                // as graphQL task
+                if (parentNode.extras.inputs.inputParameters?.http_request?.graphQLBody != null) {
+                  parentNode.extras.inputs.inputParameters.http_request.body =
+                      parentNode.extras.inputs.inputParameters.http_request.graphQLBody;
+                  delete parentNode.extras.inputs.inputParameters.http_request.graphQLBody;
+                } else {
+                  tasks.push(parentNode.extras.inputs);
+                }
+              } else if (parentNode.name === "RAW") {
                 tasks.push(handleRawNode(parentNode.extras.inputs));
               } else {
                 tasks.push(parentNode.extras.inputs);


### PR DESCRIPTION
We don't need a dedicated worker for graphql, just use http worker but
keep graphQL task in builder as "syntactic sugar"

Signed-off-by: Maros Marsalek <mmarsalek@frinx.io>