### PR TITLE
Fixing builder redirect and task name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frinx-workflow-ui",
-  "version": "1.1.58",
+  "version": "1.1.59",
   "main": "lib/App.js",
   "author": "frinx",
   "license": "MIT",

--- a/src/ServiceUiApp.js
+++ b/src/ServiceUiApp.js
@@ -38,6 +38,15 @@ function App(props) {
       <Provider store={store}>
         <BrowserRouter>
           <Switch>
+            <Redirect
+              exact
+              from={[
+                (props.frontendUrlPrefix || frontendUrlPrefix) + '/builder',
+                (props.frontendUrlPrefix || frontendUrlPrefix) +
+                  '/builder/:h/:vno',
+              ]}
+              to={(props.frontendUrlPrefix || frontendUrlPrefix) + '/defs'}
+            />
             <Route
               exact
               path={[

--- a/src/pages/diagramBuilder/Sidemenu/Sidemenu.js
+++ b/src/pages/diagramBuilder/Sidemenu/Sidemenu.js
@@ -385,7 +385,7 @@ const tasks = props => {
             ? task.description
             : '',
         }}
-        name={task.name}
+        name={task.name.replace(props.prefixHttpTask, '')}
       />
     );
   });


### PR DESCRIPTION
When user tries to go to the builder URL in the service menu
he should be redirected back to the initial screen.

In the tasks menu remove the name prefix from global context so
the user sees only the name of the task.

