### PR TITLE
fix warning for missing react keys in workflow table

### DIFF
--- a/src/pages/workflowList/WorkflowDefs/WorkflowDefs.js
+++ b/src/pages/workflowList/WorkflowDefs/WorkflowDefs.js
@@ -272,7 +272,7 @@ function WorkflowDefs(props) {
   const filteredRows = () => {
     return pageItems.map((e) => {
       return (
-        <Table.Row>
+        <Table.Row key={`${e.name}-${e.version}`}>
           <Table.Cell>
             <Header as="h4">
               <Header.Content>
@@ -307,7 +307,7 @@ function WorkflowDefs(props) {
               }
               header={<h4>Used directly in following workflows:</h4>}
               content={getDependencies(e).usedInWfs.map((wf) => (
-                <p>{wf.name}</p>
+                <p key={wf.id}>{wf.name}</p>
               ))}
               basic
             />


### PR DESCRIPTION
## Summary
Add missing `key` to each row in the workflow table to suppress react warnings.

## Test Plan
Run the app and check browser console (it should no longer show error).

## Other comments
I used a combination of name and version to create the key for each item as the key must be unique. I don't know if this is ideal, but I cannot imagine a situation where your workflow would have the same name and the same version.
