### PR TITLE
Make json parsing for input params optional on failure

### DIFF
--- a/src/pages/workflowList/WorkflowDefs/InputModal/InputModal.js
+++ b/src/pages/workflowList/WorkflowDefs/InputModal/InputModal.js
@@ -166,10 +166,15 @@ function InputModal(props) {
     };
 
     workflowFormCopy.forEach(({label, value}) => {
-      input[label] =
-        typeof value === 'string' && value.startsWith('{')
-          ? JSON.parse(value)
-          : value;
+      let parsedValue = value;
+      if (typeof value === 'string' && value.trim().startsWith('{')) {
+        try {
+          parsedValue = JSON.parse(value);
+        } catch {
+          // not a valid json, use default string value
+        }
+      }
+      input[label] = parsedValue;
     });
 
     setStatus('Executing...');


### PR DESCRIPTION
Signed-off-by: Maros Marsalek <mmarsalek@frinx.io>

## Summary
Use raw string as input parameter if it resembles json but cannot be parsed