### PR TITLE
fix grahpql task in workflow builder

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,18 +17,6 @@ module.exports.overrides = [
       node: true,
     },
     files: ['*'],
-    rules: {
-      'prettier/prettier': [
-        2,
-        {
-          singleQuote: true,
-          trailingComma: 'all',
-          bracketSpacing: false,
-          jsxBracketSameLine: true,
-          parser: 'flow',
-        },
-      ],
-    },
   },
   {
     files: ['.eslintrc.js'],
@@ -41,25 +29,13 @@ module.exports.overrides = [
       jest: true,
       node: true,
     },
-    files: [
-      '**/__mocks__/**/*.js',
-      '**/__tests__/**/*.js',
-      '**/tests/*.js',
-      'testHelpers.js',
-      'testData.js',
-    ],
+    files: ['**/__mocks__/**/*.js', '**/__tests__/**/*.js', '**/tests/*.js', 'testHelpers.js', 'testData.js'],
   },
   {
     env: {
       node: true,
     },
-    files: [
-      '.eslintrc.js',
-      'babel.config.js',
-      'jest.config.js',
-      'jest.*.config.js',
-      'src/**/*.js'
-    ],
+    files: ['.eslintrc.js', 'babel.config.js', 'jest.config.js', 'jest.*.config.js', 'src/**/*.js'],
     rules: {
       'no-console': 'off',
     },

--- a/src/common/GlobalContext.js
+++ b/src/common/GlobalContext.js
@@ -4,7 +4,7 @@ import React, { createContext, useEffect, useState } from 'react';
 export const GlobalContext = createContext();
 
 export const globalConstants = {
-  backendApiUrlPrefix: 'https://localhost/uniflow/api/conductor',
+  backendApiUrlPrefix: '/uniflow/api/conductor',
   frontendUrlPrefix: '/uniflow/ui',
   enableScheduling: true,
   disabledTasks: ['js', 'py', 'while', 'while_end'],

--- a/src/common/GlobalContext.js
+++ b/src/common/GlobalContext.js
@@ -4,10 +4,10 @@ import React, { createContext, useEffect, useState } from 'react';
 export const GlobalContext = createContext();
 
 export const globalConstants = {
-  backendApiUrlPrefix: '/uniflow/api/conductor',
+  backendApiUrlPrefix: 'https://localhost/uniflow/api/conductor',
   frontendUrlPrefix: '/uniflow/ui',
   enableScheduling: true,
-  disabledTasks: ['js', 'py', 'graphQL', 'while', 'while_end'],
+  disabledTasks: ['js', 'py', 'while', 'while_end'],
   prefixHttpTask: '',
   // Uncomment below settings when testing frinx-workflow-ui running on host and talking to workflow-proxy in net-auto
   /*

--- a/src/pages/diagramBuilder/NodeModal/InputsTab.js
+++ b/src/pages/diagramBuilder/NodeModal/InputsTab.js
@@ -22,8 +22,8 @@ import 'codemirror/lib/codemirror.css';
 import 'codemirror/theme/xq-light.css';
 import { Controlled as CodeMirror } from 'react-codemirror2';
 
-const TEXTFIELD_KEYWORDS = ['template', 'uri', 'body'];
-const CODEFIELD_KEYWORDS = ['scriptExpression', 'raw', 'graphQLBody'];
+const TEXTFIELD_KEYWORDS = ['template', 'uri'];
+const CODEFIELD_KEYWORDS = ['scriptExpression', 'raw'];
 const SELECTFIELD_KEYWORDS = ['method', 'action', 'expectedType'];
 const KEYFIELD_KEYWORDS = ['headers'];
 const SELECTFIELD_OPTIONS = {
@@ -113,11 +113,10 @@ const InputsTab = props => {
   const creategraphQLField = (entry, item) => {
     /* FIXME graphQL editor : implement schema validation*/
     //  let schema = buildSchema(`...`);
-
     textFieldParams.push(
       <Col sm={12} key={`colTf-${entry[0]}`}>
         <Form.Group>
-          <Form.Label>{entry[0]}</Form.Label>
+          <Form.Label>{entry[0] === 'body' ? 'graphQLBody' : entry[0]}</Form.Label>
           <CodeMirror
             value={entry[1]}
             options={{
@@ -251,14 +250,16 @@ const InputsTab = props => {
   };
 
   const handleInputField = (entry, item) => {
-    if (TEXTFIELD_KEYWORDS.find(keyword => entry[0].includes(keyword))) {
-      createTextField(entry, item);
-    } else if (CODEFIELD_KEYWORDS.find(keyword => entry[0].includes(keyword))) {
-      if (entry[0].includes('graphQLBody')) {
+    if (entry[0].includes('graphQLBody') || entry[0].includes('body')) {
+      if (props.taskReferenceName.includes('graphQLTaskRef_')) {
         creategraphQLField(entry, item);
       } else {
-        createCodeField(entry, item);
+        createTextField(entry, item);
       }
+    } else if (TEXTFIELD_KEYWORDS.find(keyword => entry[0].includes(keyword))) {
+      createTextField(entry, item);
+    } else if (CODEFIELD_KEYWORDS.find(keyword => entry[0].includes(keyword))) {
+      createCodeField(entry, item);
     } else if (SELECTFIELD_KEYWORDS.find(keyword => entry[0].includes(keyword))) {
       return createSelectField(entry, item);
     } else if (KEYFIELD_KEYWORDS.find(keyword => entry[0].includes(keyword))) {

--- a/src/pages/diagramBuilder/NodeModal/NodeModal.js
+++ b/src/pages/diagramBuilder/NodeModal/NodeModal.js
@@ -157,7 +157,10 @@ function NodeModal(props) {
     if (typeof key[1] === 'object') {
       if (entry[0] === 'headers') {
         value = updateHTTPHeader(value, i, headerKey);
-      } else if (OBJECT_KEYWORDS.find(e => entry[0].includes(e))) {
+      } else if (
+        OBJECT_KEYWORDS.find(e => entry[0].includes(e)) &&
+        !props.inputs.inputs.taskReferenceName.includes('graphQLTaskRef_')
+      ) {
         try {
           value = JSON.parse(value);
         } catch (e) {
@@ -249,6 +252,7 @@ function NodeModal(props) {
               removeInputParam={removeInputParam}
               inputParameters={inputParameters}
               addRemoveHeader={addRemoveHeader}
+              taskReferenceName={props.inputs.inputs.taskReferenceName}
             />
           </Tab>
         </Tabs>

--- a/src/pages/diagramBuilder/WorkflowDiagram.js
+++ b/src/pages/diagramBuilder/WorkflowDiagram.js
@@ -679,8 +679,6 @@ export class WorkflowDiagram {
       lastNode = parentNode;
     }
 
-    console.log(branchTask);
-    console.log(lastNode.x);
     let branchPosX = lastNode.x + 150 + (this.getNodeWidth(lastNode) + 50);
 
     return { branchPosX, branchPosY };
@@ -819,7 +817,11 @@ export class WorkflowDiagram {
         } else if (task.type == 'SIMPLE' && task.name == 'GLOBAL___graphQL') {
           node = this.placeGraphQLNode(task, x, y);
         } else if (task.type == 'SIMPLE' && task.name == this.prefixHttpTask + 'HTTP_task') {
-          node = this.placeHTTPNode(task, x, y);
+          if (task.taskReferenceName.includes('graphQLTaskRef_')) {
+            node = this.placeGraphQLNode(task, x, y);
+          } else {
+            node = this.placeHTTPNode(task, x, y);
+          }
         } else if (task.name === 'DYNAMIC_FORK') {
           node = this.placeDynamicForkNode(task, x, y);
         } else {
@@ -940,9 +942,8 @@ export class WorkflowDiagram {
               parentNode.extras.inputs.inputParameters.http_request.body =
                 parentNode.extras.inputs.inputParameters.http_request.graphQLBody;
               delete parentNode.extras.inputs.inputParameters.http_request.graphQLBody;
-            } else {
-              tasks.push(parentNode.extras.inputs);
             }
+            tasks.push(parentNode.extras.inputs);
           } else if (parentNode.name === 'RAW') {
             tasks.push(handleRawNode(parentNode.extras.inputs));
           } else {


### PR DESCRIPTION
## Summary
Fix behaviour of GraphQL task in the workflow builder, make it persistent now. Previously, after you saved a workflow with a graphql task, it would use a basic HTTP task instead next time you open it.

## Test Plan
Create a new workflow, add a GraphQL task, save it, reload it. After reload, you should see a GraphQL task present, not a basic HTTP task.

## Other comments
This change is not ideal, but that would require a serious refactor (maybe even on the back-end side). 
