### PR TITLE
fix build process for library target

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,11 +3,11 @@ name: Release & Publish
 on:
   push:
     tags:
-      - v*        # Publish `v1.2.3` tags as (npm) releases.
+      - v* # Publish `v1.2.3` tags as (npm) releases.
 
 jobs:
   publish:
-    name: "Publish to npm"
+    name: 'Publish to npm'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -16,17 +16,15 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '12'
-      - name: install babel
+      - name: install deps
         run: |
-          npm install --save-dev @babel/core @babel/cli
-      - name: npm run transpile
+          npm install
+      - name: npm run build
         run: |
           ls -l
-          npm run transpile
+          npm run build
       - name: publish
         run: |
-          cd build
-          ls -l
           npm config set //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN
           npm publish
         env:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
   "name": "frinx-workflow-ui",
   "version": "1.1.64",
-  "main": "lib/App.js",
+  "main": "dist/index.js",
+  "module": "src/index.js",
+  "files": [
+    "dist/*"
+  ],
   "author": "frinx",
   "license": "BSD-3-Clause",
   "dependencies": {
@@ -27,12 +31,10 @@
     "node-sass": "^4.14.1",
     "pathfinding": "^0.4.18",
     "paths-js": "^0.4.10",
-    "react": "^16.8.4",
     "react-ace": "latest",
     "react-bootstrap": "^1.0.0-beta.8",
     "react-bootstrap-typeahead": "^3.4.5",
     "react-contexify": "^4.1.1",
-    "react-dom": "^16.8.4",
     "react-dropdown": "^1.6.4",
     "react-highlight.js": "^1.0.7",
     "react-hotkeys": "^2.0.0-pre9",
@@ -57,7 +59,7 @@
     "start": "webpack-dev-server --mode development",
     "transpile": "babel src -d lib --copy-files && mkdir -p build && cp -r lib/ package.json package-lock.json README.md build",
     "debug": "PORT=3002 react-scripts --inspect-brk start",
-    "build": "webpack --mode production",
+    "build": "NODE_ENV=production webpack --mode production",
     "flow": "flow",
     "formatter": "prettier --write 'src/*.js' 'src/**/*.js' package.json",
     "formatter:check": "prettier -l 'src/*.js' 'src/**/*.js' package.json"
@@ -100,8 +102,14 @@
     "flow-remove-types": "^2.125.1",
     "jsdoc": "^3.6.3",
     "prettier": "^1.18.2",
+    "react": "^16.8.4",
+    "react-dom": "^16.8.4",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",
     "webpack-dev-server": "^3.10.3"
+  },
+  "peerDependencies": {
+    "react": "^16.8.4",
+    "react-dom": "^16.8.4"
   }
 }

--- a/src/ServiceUiApp.js
+++ b/src/ServiceUiApp.js
@@ -10,7 +10,6 @@ import { applyMiddleware, combineReducers, compose, createStore } from 'redux';
 import thunk from 'redux-thunk';
 import buildReducer from './store/reducers/builder';
 import bulkReducer from './store/reducers/bulk';
-import mountedDeviceReducer from './store/reducers/mountedDevices';
 import searchReducer from './store/reducers/searchExecs';
 import Header from './common/header/Header';
 import { GlobalProvider, globalConstants } from './common/GlobalContext';
@@ -20,7 +19,6 @@ const rootReducer = combineReducers({
   bulkReducer,
   searchReducer,
   buildReducer,
-  mountedDeviceReducer,
 });
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
@@ -29,7 +27,7 @@ const store = createStore(rootReducer, composeEnhancers(applyMiddleware(thunk)))
 
 const { frontendUrlPrefix } = globalConstants;
 
-function App(props) {
+function ServiceUIApp(props) {
   return (
     <GlobalProvider {...props}>
       <Provider store={store}>
@@ -65,4 +63,4 @@ function App(props) {
   );
 }
 
-export default App;
+export default ServiceUIApp;

--- a/src/index-dev.js
+++ b/src/index-dev.js
@@ -1,0 +1,6 @@
+// @flow
+import App from './App';
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import App from './App';
+// @flow
+import ServiceUIApp from './ServiceUiApp';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+export { ServiceUIApp };

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,6 @@
 // @flow
+import App from './App';
 import ServiceUIApp from './ServiceUiApp';
 
 export { ServiceUIApp };
+export { App as WorkflowApp };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,11 @@
-const HtmlWebPackPlugin = require("html-webpack-plugin");
+// @flow weak
+const path = require('path');
+const HtmlWebPackPlugin = require('html-webpack-plugin');
 
+const isDev = process.env.NODE_ENV !== 'production';
 
 module.exports = {
+  entry: isDev ? path.resolve(__dirname, 'src/index-dev.js') : path.resolve(__dirname, 'src/index.js'),
   devServer: {
     historyApiFallback: true,
     inline: true,
@@ -21,30 +25,35 @@ module.exports = {
         secure: false,
       }
       */
-    }
+    },
   },
   output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'index.js',
+    library: 'frinxWorkflowUI',
+    libraryTarget: 'umd',
     publicPath: '/',
     // Substitute publicPath above with settings below when testing frinx-workflow-ui running on host and talking to workflow-proxy in net-auto
     /*
     publicPath: '/workflow/frontend/',
     */
   },
-  devtool: 'source-map',
+  devtool: isDev ? 'source-map' : undefined,
   module: {
     rules: [
       {
         test: /\.(css|scss})$/,
-        loader: 'style-loader!css-loader!sass-loader'},
+        loader: 'style-loader!css-loader!sass-loader',
+      },
       {
         test: /\.m?js$/,
         exclude: /(node_modules)/,
         use: {
           loader: 'babel-loader',
           options: {
-            presets: ['@babel/preset-env']
-          }
-        }
+            presets: ['@babel/preset-env'],
+          },
+        },
       },
       {
         test: /\.(jpe?g|gif|png|svg|)$/i,
@@ -56,22 +65,28 @@ module.exports = {
       },
       {
         test: /\.(woff|woff2|ttf|eot)$/,
-        use: 'file-loader?name=fonts/[name].[ext]!static'
+        use: 'file-loader?name=fonts/[name].[ext]!static',
       },
       {
         test: /\.html$/,
         use: [
           {
-            loader: "html-loader"
-          }
-        ]
-      }
-    ]
+            loader: 'html-loader',
+          },
+        ],
+      },
+    ],
   },
   plugins: [
     new HtmlWebPackPlugin({
-      template: "./public/index.html",
-      filename: "./index.html"
-    })
-  ]
+      template: './public/index.html',
+      filename: './index.html',
+    }),
+  ],
+  externals: isDev
+    ? undefined
+    : {
+        react: 'react',
+        reactDOM: 'react-dom',
+      },
 };


### PR DESCRIPTION
## Summary
Fixed the whole building process for building this app as a library (as it's later consumed by other packages):
- first, we need to update the webpack config accordingly
- second, we need to remove `react` and `react-dom` from `dependencies`, as it could cause issues with two instances of react running on the same page (react from this package + react from the "consumer" app) - we also need to add them to `peerDependencies` (and `devDependencies` - we want to be able to run it during development obviously)
- third, we update `package.json` so the npm knows how to use this as a library
- last, we update the GitHub workflow - as per previous steps, we could simplify this

## Test Plan
Smoke check the app in development (`npm start`). Other than that, we will see if it will work in "consumer" apps

## Other comments
This setup is not actually ideal, but I didn't really want to introduce too much stuff at once - we should use something like lerna (https://github.com/lerna/lerna)/yarn workspaces/npm workspaces, where we have one package for the library itself and one package for development (fake consumer)
