### PR TITLE
Add workflow tree view

### DIFF
--- a/src/pages/workflowList/WorkflowDefs/WorkflowDefs.js
+++ b/src/pages/workflowList/WorkflowDefs/WorkflowDefs.js
@@ -16,6 +16,7 @@ import { GlobalContext } from '../../../common/GlobalContext';
 import PaginationPages from '../../../common/Pagination';
 import { usePagination } from '../../../common/PaginationHook';
 import { jsonParse } from '../../../common/utils';
+import WorkflowListViewModal from './WorkflowListViewModal/WorkflowListViewModal.js';
 
 const getLabels = dataset => {
   let labelsArr = dataset.map(({ description }) => {
@@ -41,6 +42,7 @@ function WorkflowDefs(props) {
   const [dependencyModal, setDependencyModal] = useState(false);
   const [schedulingModal, setSchedulingModal] = useState(false);
   const [confirmDeleteModal, setConfirmDeleteModal] = useState(false);
+  const [workflowListViewModal, setWorkflowListViewModal] = useState(false);
   const [allLabels, setAllLabels] = useState([]);
   const { currentPage, setCurrentPage, pageItems, setItemList, totalPages } = usePagination([], 10);
 
@@ -178,6 +180,13 @@ function WorkflowDefs(props) {
         <Button title="Diagram" basic circular icon="fork" onClick={() => showDiagramModal(dataset)} />
         <Button title="Definition" basic circular icon="file code" onClick={() => showDefinitionModal(dataset)} />
         <Button
+          title="Workflow List"
+          basic
+          circular
+          icon="list ul"
+          onClick={() => showWorkflowListViewModal(dataset)}
+        />
+        <Button
           title="Edit"
           basic
           circular
@@ -287,6 +296,11 @@ function WorkflowDefs(props) {
     setActiveWf(workflow);
   };
 
+  const showWorkflowListViewModal = workflow => {
+    setWorkflowListViewModal(!workflowListViewModal);
+    setActiveWf(workflow);
+  };
+
   const getActiveWfScheduleName = () => {
     if (activeWf != null && activeWf.expectedScheduleName != null) {
       return activeWf.expectedScheduleName;
@@ -312,6 +326,17 @@ function WorkflowDefs(props) {
 
   const renderDiagramModal = () => {
     return diagramModal ? <DiagramModal wf={activeWf} modalHandler={showDiagramModal} show={diagramModal} /> : null;
+  };
+
+  const renderWorkflowListViewModal = () => {
+    return workflowListViewModal ? (
+      <WorkflowListViewModal
+        wf={activeWf}
+        modalHandler={showWorkflowListViewModal}
+        show={workflowListViewModal}
+        data={data}
+      />
+    ) : null;
   };
 
   const renderSchedulingModal = () => {
@@ -359,6 +384,7 @@ function WorkflowDefs(props) {
       {renderDependencyModal()}
       {renderSchedulingModal()}
       {renderConfirmDeleteModal()}
+      {renderWorkflowListViewModal()}
       <Row>
         <Button
           primary

--- a/src/pages/workflowList/WorkflowDefs/WorkflowListViewModal/WorkflowListViewModal.js
+++ b/src/pages/workflowList/WorkflowDefs/WorkflowListViewModal/WorkflowListViewModal.js
@@ -1,0 +1,159 @@
+import React, { useContext, useEffect, useState } from 'react';
+import _ from 'lodash';
+import { Button, Modal } from 'react-bootstrap';
+import { List } from 'semantic-ui-react';
+import { jsonParse } from '../../../../common/utils.js';
+import { hash } from '../../../diagramBuilder/builder-utils';
+import { GlobalContext } from '../../../../common/GlobalContext.js';
+
+function createWorkflowTree(tasks, workflows) {
+  return _.flatMap(tasks, task => {
+    return {
+      name: task.name,
+      taskReferenceName: task.taskReferenceName,
+      subWorkflowParam: task?.subWorkflowParam,
+      description: jsonParse(task.description)?.description,
+      subtasks: getSubTasks(task, workflows),
+    };
+  });
+}
+
+function getSubTasks(task, workflows) {
+  if (task.type === 'SUB_WORKFLOW') {
+    const subwf = _.find(workflows, { name: task.name });
+
+    return createWorkflowTree(subwf?.tasks, workflows);
+  }
+
+  if (task.type === 'DECISION') {
+    const { decisionCases } = task;
+    const nonDefaultCaseName = Object.keys(decisionCases)[0];
+
+    // there are always only 2 branches in current impl
+    const decisionBranches = [
+      {
+        name: nonDefaultCaseName,
+        tasks: decisionCases[nonDefaultCaseName],
+      },
+      {
+        name: 'defaultCase',
+        tasks: task.defaultCase,
+      },
+    ];
+
+    return _.flatMap(decisionBranches, branch => {
+      return {
+        name: branch.name,
+        // we need to create unique ID to be able to hide the branch in tree
+        taskReferenceName: branch.name + hash(),
+        subtasks: createWorkflowTree(branch.tasks, workflows),
+      };
+    });
+  }
+
+  if (task.type === 'FORK_JOIN') {
+    const { forkTasks } = task;
+
+    return _.flatMap(forkTasks, (branch, i) => {
+      return {
+        name: `branch ${i}`,
+        // we need to create unique ID to be able to hide the branch in tree
+        taskReferenceName: `branch ${i}` + hash(),
+        subtasks: createWorkflowTree(branch, workflows),
+      };
+    });
+  }
+
+  return [];
+}
+
+const WorkflowListViewModal = props => {
+  const global = useContext(GlobalContext);
+  const [workflowTree, setWorkflowTree] = useState([]);
+  const [hiddenTasks, setHiddenTasks] = useState([]);
+
+  useEffect(() => {
+    const { tasks } = props.wf;
+    const workflows = props.data;
+    setWorkflowTree(createWorkflowTree(tasks, workflows));
+  }, []);
+
+  function showHideTask(task) {
+    if (hiddenTasks.includes(task.taskReferenceName)) {
+      setHiddenTasks(oldArray => oldArray.filter(item => item !== task.taskReferenceName));
+    } else {
+      setHiddenTasks(oldArray => [...oldArray, task.taskReferenceName]);
+    }
+  }
+
+  function renderHeader(task) {
+    if (task.subWorkflowParam) {
+      return (
+        <a
+          title="Click to open workflow in builder"
+          target="_blank"
+          href={`${global.frontendUrlPrefix}/builder/${task?.subWorkflowParam?.name}/${task?.subWorkflowParam?.version}`}
+        >
+          {task.name}
+        </a>
+      );
+    }
+
+    return task.name;
+  }
+
+  function renderSubtasks(task) {
+    if (task?.subtasks?.length > 0) {
+      return (
+        <List.Item key={task.taskReferenceName}>
+          <List.Icon
+            link
+            name={hiddenTasks.includes(task.taskReferenceName) ? 'folder open' : 'folder'}
+            onClick={() => showHideTask(task)}
+          />
+          <List.Content>
+            <List.Header>{renderHeader(task)}</List.Header>
+            <List.Description>{task?.description}</List.Description>
+            {hiddenTasks.includes(task.taskReferenceName) && (
+              <List.List>{task.subtasks.map(st => renderSubtasks(st))}</List.List>
+            )}
+          </List.Content>
+        </List.Item>
+      );
+    }
+
+    return (
+      <List.Item key={task.taskReferenceName}>
+        <List.Icon name="sticky note outline" />
+        <List.Content>
+          <List.Header>{task.name}</List.Header>
+          <List.Description>{task?.description}</List.Description>
+        </List.Content>
+      </List.Item>
+    );
+  }
+
+  const renderWorkflowAsTree = () => <List>{workflowTree.map(t => renderSubtasks(t))}</List>;
+
+  return (
+    <Modal size="lg" dialogClassName="modal-70w" show={props.show} onHide={props.modalHandler}>
+      <Modal.Header>
+        <Modal.Title>
+          {props?.wf?.name}
+          <br />
+          <div style={{ fontSize: '18px' }}>
+            <p className="text-muted">{jsonParse(props?.wf?.description)?.description}</p>
+          </div>
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body style={{ padding: '30px' }}>{renderWorkflowAsTree()}</Modal.Body>
+      <Modal.Footer>
+        <Button variant="secondary" onClick={props.modalHandler}>
+          Close
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+export default WorkflowListViewModal;

--- a/src/pages/workflowList/WorkflowDefs/WorkflowListViewModal/WorkflowListViewModal.js
+++ b/src/pages/workflowList/WorkflowDefs/WorkflowListViewModal/WorkflowListViewModal.js
@@ -42,7 +42,7 @@ function getSubTasks(task, allWorkflows) {
       },
     ];
 
-    return _.flatMap(decisionBranches, branch => {
+    return decisionBranches.map(branch => {
       return {
         name: branch.name,
         // we need to create unique ID to be able to expand/hide the branch in tree
@@ -55,7 +55,7 @@ function getSubTasks(task, allWorkflows) {
   if (task.type === 'FORK_JOIN') {
     const { forkTasks } = task;
 
-    return _.flatMap(forkTasks, (branch, i) => {
+    return forkTasks.map((branch, i) => {
       return {
         name: `branch ${i}`,
         // we need to create unique ID to be able to expand/hide the branch in tree
@@ -71,7 +71,7 @@ function getSubTasks(task, allWorkflows) {
 const WorkflowListViewModal = props => {
   const global = useContext(GlobalContext);
   const [workflowTree, setWorkflowTree] = useState([]);
-  const [expandedTasks, setexpandedTasks] = useState([]);
+  const [expandedTasks, setExpandedTasks] = useState([]);
 
   useEffect(() => {
     const { tasks } = props.wf;
@@ -81,9 +81,9 @@ const WorkflowListViewModal = props => {
 
   function expandHideTask(task) {
     if (expandedTasks.includes(task.taskReferenceName)) {
-      setexpandedTasks(oldArray => oldArray.filter(item => item !== task.taskReferenceName));
+      setExpandedTasks(oldArray => oldArray.filter(item => item !== task.taskReferenceName));
     } else {
-      setexpandedTasks(oldArray => [...oldArray, task.taskReferenceName]);
+      setExpandedTasks(oldArray => [...oldArray, task.taskReferenceName]);
     }
   }
 


### PR DESCRIPTION
## Summary
Simplified and expandable list of tasks and subworkflow for selected workflow.

- Each subworkflow (on click) opens builder in new tab 

## Other comments
- There are currently 3 different views to display workflow - JSON, Diagram, Tree - each has one button for it. We should maybe think of merging those 3 views under one button/view ...

## Screenshots

![image](https://user-images.githubusercontent.com/32128755/104931133-4ca11380-59a6-11eb-8bef-11bace11efd8.png)
